### PR TITLE
Look for supported type of storage to use

### DIFF
--- a/_js/app.js
+++ b/_js/app.js
@@ -6,7 +6,17 @@ $(document).ready(function () {
         }
     });
 
-    var store = new Sammy.Store({name: 'storage', type: 'session'});
+    // Look for supported type of storage to use
+    var storageType;
+    if (Sammy.Store.isAvailable('session')) {
+        storageType = 'session';
+    } else if (Sammy.Store.isAvailable('cookie')) {
+        storageType = 'cookie';
+    } else {
+        storageType = 'memory';        
+    }
+
+    var store = new Sammy.Store({name: 'storage', type: storageType});
 
     var app = Sammy('#content', function(sam) {
 


### PR DESCRIPTION
Looks for supported type of storage to use in order to improve browser compatibility.

HTML5 DOM storage is not widely supported. Moreover it could become a threat to our privacy and be disabled since it is used by some web sites to track visitors.
