### PR TITLE
Fix language availability checking

### DIFF
--- a/_js/app.js
+++ b/_js/app.js
@@ -246,7 +246,7 @@ $(document).ready(function () {
                 changeLanguage(store.get('lang'));
             } else {
                 language = window.navigator.language.substr(0, 2);
-                if (typeof i18n[language] !== undefined) {
+                if (typeof i18n[language] !== 'undefined') {
                     changeLanguage(language);
                 } else {
                     changeLanguage(conf.defaultLanguage);


### PR DESCRIPTION
The typeof operator returns a string: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof
