### PR TITLE
Remove page renaming when default language is requested

### DIFF
--- a/_js/app.js
+++ b/_js/app.js
@@ -38,10 +38,6 @@ $(document).ready(function () {
                         page = page +'_'+ currentLang;
                         c.viewPage(page);
                     }
-                } else if (page.substr(page.length - 2) == conf.defaultLanguage) {
-                    // Indicate page specifically
-                    page = page.substr(0, page.length - 3);
-                    c.viewPage(page);
                 }
                 store.set('page', page);
 


### PR DESCRIPTION
Remove remaining code which makes troubles when the page is requested using the default language.
